### PR TITLE
feat:🆕  Add Firestore source

### DIFF
--- a/megalist_dataflow/models/options.py
+++ b/megalist_dataflow/models/options.py
@@ -32,6 +32,8 @@ class DataflowOptions(PipelineOptions):
     parser.add_value_provider_argument(
         '--setup_sheet_id', help='Id of Spreadsheet with execution info')
     parser.add_value_provider_argument(
+        '--setup_firestore_collection', help='Name of Firestore collection with execution info')
+    parser.add_value_provider_argument(
         '--bq_ops_dataset',
         help='Auxliary bigquery dataset used for Megalista operations')
     # Google Ads

--- a/megalist_dataflow/sources/firestore_execution_source.py
+++ b/megalist_dataflow/sources/firestore_execution_source.py
@@ -1,0 +1,127 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import distutils.util
+import logging
+
+from apache_beam.options.value_provider import ValueProvider
+
+from google.cloud import firestore
+from sources.base_bounded_source import BaseBoundedSource
+from models.execution import Destination, DestinationType
+from models.execution import Execution, AccountConfig
+from models.execution import Source, SourceType
+
+
+class FirestoreExecutionSource(BaseBoundedSource):
+  """
+  Read Execution data from a Firestore collection. The collection name is set-up in the parameter "setup_firestore_collection"
+  """
+
+  def __init__(
+      self,
+      setup_firestore_collection: ValueProvider
+  ):
+    super().__init__()
+    self._setup_firestore_collection = setup_firestore_collection
+
+  def _do_count(self):
+    # TODO: implement count
+    return 3
+
+  def read(self, range_tracker):
+    def document_to_dict(doc):
+      if not doc.exists:
+          return None
+      doc_dict = doc.to_dict()
+      doc_dict['id'] = doc.id
+      return doc_dict
+
+    firestore_collection = self._setup_firestore_collection.get()
+    logging.getLogger("megalista.FirestoreExecutionSource").info(f"Loading Firestore collection {firestore_collection}...")
+    db = firestore.Client()
+    entries = db.collection(self._setup_firestore_collection.get()).where('active', '==', 'yes').stream()
+    entries = [document_to_dict(doc) for doc in entries]
+    
+    account_data = document_to_dict(db.collection(self._setup_firestore_collection.get()).document('account_config').get())
+  
+    if not account_data:
+      raise Exception('Firestore collection is absent')
+    google_ads_id = account_data.get('google_ads_id', 'chave_vazia')
+    mcc_trix = account_data.get('mcc_trix', 'FALSE')
+    mcc = False if mcc_trix is None else bool(distutils.util.strtobool(mcc_trix))
+    app_id = account_data.get('app_id', 'chave_vazia')
+    google_analytics_account_id = account_data.get('google_analytics_account_id', 'chave_vazia')
+    campaign_manager_account_id = account_data.get('campaign_manager_account_id', 'chave_vazia')
+    
+    account_config = AccountConfig(google_ads_id, mcc, google_analytics_account_id, campaign_manager_account_id, app_id)
+    logging.getLogger("megalista.FirestoreExecutionSource").info(f"Loaded: {account_config}")
+    
+    sources = self._read_sources(entries)
+    destinations = self._read_destination(entries)
+    if entries:
+      for entry in entries:
+        if entry['active'].upper() == 'YES':
+          logging.getLogger("megalista.FirestoreExecutionSource").info(
+            f"Executing step Source:{sources[entry['id'] + '_source'].source_name} -> Destination:{destinations[entry['id'] + '_destination'].destination_name}")
+          yield Execution(account_config, sources[entry['id'] + '_source'], destinations[entry['id'] + '_destination'])
+    else:
+      logging.getLogger("megalista.FirestoreExecutionSource").warn("No schedules found!")
+
+  @staticmethod
+  def _read_sources(entries):
+    sources = {}
+    if entries:
+      for entry in entries:
+        metadata = [entry['bq_dataset'], entry['bq_table']] #TODO: flexibilize for other source types
+        source = Source(entry['id'] + '_source', SourceType[entry['source']], metadata)
+        sources[source.source_name] = source
+    else:
+      logging.getLogger("megalista.FirestoreExecutionSource").warn("No sources found!")
+    return sources
+
+  @staticmethod
+  def _read_destination(entries):
+    def create_metadata_list(entry):
+      metadata_list = {
+        'ADS_OFFLINE_CONVERSION': ['gads_conversion_name'],
+        'ADS_SSD_UPLOAD': ['gads_conversion_name', 'gads_external_upload_id'],
+        'ADS_CUSTOMER_MATCH_CONTACT_INFO_UPLOAD': ['gads_audience_name', 'gads_operation', 'gads_hash'],
+        'ADS_CUSTOMER_MATCH_MOBILE_DEVICE_ID_UPLOAD': ['gads_audience_name', 'gads_operation', 'gads_metadata3', 'gads_app_id'],
+        'ADS_CUSTOMER_MATCH_USER_ID_UPLOAD': ['gads_audience_name', 'gads_operation', 'gads_metadata3'],
+        'GA_MEASUREMENT_PROTOCOL': ['google_analytics_property_id', 'google_analytics_non_interaction'],
+        'CM_OFFLINE_CONVERSION': ['campaign_manager_floodlight_activity_id', 'campaign_manager_floodlight_configuration_id'],
+        'APPSFLYER_S2S_EVENTS': ['appsflyer_app_id'],
+      }
+
+      entry_type = entry['type']
+      metadata = metadata_list.get(entry_type, None)
+      if not metadata: 
+        raise Exception(f'Upload type not implemented: {entry_type}')
+      entry_metadata = []
+      for m in metadata:
+        if m in entry:
+          entry_metadata.append(entry[m])
+        else:
+          raise Exception(f'Missing field in Firestore document for {entry_type}: {m}')
+      return entry_metadata
+
+
+    destinations = {}
+    if entries:
+      for entry in entries:
+        destination = Destination(entry['id'] + '_destination', DestinationType[entry['type']], create_metadata_list(entry))
+        destinations[destination.destination_name] = destination
+    else:
+      logging.getLogger("megalista.FirestoreExecutionSource").warn("No destinations found!")
+    return destinations

--- a/megalist_dataflow/sources/firestore_execution_source.py
+++ b/megalist_dataflow/sources/firestore_execution_source.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -57,12 +57,12 @@ class FirestoreExecutionSource(BaseBoundedSource):
   
     if not account_data:
       raise Exception('Firestore collection is absent')
-    google_ads_id = account_data.get('google_ads_id', 'chave_vazia')
+    google_ads_id = account_data.get('google_ads_id', 'empty')
     mcc_trix = account_data.get('mcc_trix', 'FALSE')
     mcc = False if mcc_trix is None else bool(distutils.util.strtobool(mcc_trix))
-    app_id = account_data.get('app_id', 'chave_vazia')
-    google_analytics_account_id = account_data.get('google_analytics_account_id', 'chave_vazia')
-    campaign_manager_account_id = account_data.get('campaign_manager_account_id', 'chave_vazia')
+    app_id = account_data.get('app_id', 'empty')
+    google_analytics_account_id = account_data.get('google_analytics_account_id', 'empty')
+    campaign_manager_account_id = account_data.get('campaign_manager_account_id', 'empty')
     
     account_config = AccountConfig(google_ads_id, mcc, google_analytics_account_id, campaign_manager_account_id, app_id)
     logging.getLogger("megalista.FirestoreExecutionSource").info(f"Loaded: {account_config}")
@@ -97,8 +97,8 @@ class FirestoreExecutionSource(BaseBoundedSource):
         'ADS_OFFLINE_CONVERSION': ['gads_conversion_name'],
         'ADS_SSD_UPLOAD': ['gads_conversion_name', 'gads_external_upload_id'],
         'ADS_CUSTOMER_MATCH_CONTACT_INFO_UPLOAD': ['gads_audience_name', 'gads_operation', 'gads_hash'],
-        'ADS_CUSTOMER_MATCH_MOBILE_DEVICE_ID_UPLOAD': ['gads_audience_name', 'gads_operation', 'gads_metadata3', 'gads_app_id'],
-        'ADS_CUSTOMER_MATCH_USER_ID_UPLOAD': ['gads_audience_name', 'gads_operation', 'gads_metadata3'],
+        'ADS_CUSTOMER_MATCH_MOBILE_DEVICE_ID_UPLOAD': ['gads_audience_name', 'gads_operation'],
+        'ADS_CUSTOMER_MATCH_USER_ID_UPLOAD': ['gads_audience_name', 'gads_operation'],
         'GA_MEASUREMENT_PROTOCOL': ['google_analytics_property_id', 'google_analytics_non_interaction'],
         'CM_OFFLINE_CONVERSION': ['campaign_manager_floodlight_activity_id', 'campaign_manager_floodlight_configuration_id'],
         'APPSFLYER_S2S_EVENTS': ['appsflyer_app_id'],

--- a/megalist_dataflow/uploaders/google_ads/customer_match/abstract_uploader.py
+++ b/megalist_dataflow/uploaders/google_ads/customer_match/abstract_uploader.py
@@ -114,7 +114,7 @@ class GoogleAdsCustomerMatchAbstractUploaderDoFn(beam.DoFn):
 
     rows = self.get_filtered_rows(
         batch.elements, self.get_row_keys())
-        
+    
     mutate_members_operation = {
         'operand': {
             'userListId': list_id,
@@ -126,7 +126,8 @@ class GoogleAdsCustomerMatchAbstractUploaderDoFn(beam.DoFn):
     utils.safe_call_api(self.call_api, logging, user_list_service, [mutate_members_operation])
 
   def call_api(self, service, operations):
-    service.mutateMembers(operations)
+    r = service.mutateMembers(operations)
+    print(f'\n\n{r}\n\n')
 
   def get_filtered_rows(self, rows: List[Any],
                         keys: List[str]) -> List[Dict[str, Any]]:

--- a/megalist_dataflow/uploaders/google_ads/customer_match/abstract_uploader.py
+++ b/megalist_dataflow/uploaders/google_ads/customer_match/abstract_uploader.py
@@ -114,7 +114,7 @@ class GoogleAdsCustomerMatchAbstractUploaderDoFn(beam.DoFn):
 
     rows = self.get_filtered_rows(
         batch.elements, self.get_row_keys())
-    
+        
     mutate_members_operation = {
         'operand': {
             'userListId': list_id,

--- a/megalist_dataflow/uploaders/google_ads/customer_match/abstract_uploader.py
+++ b/megalist_dataflow/uploaders/google_ads/customer_match/abstract_uploader.py
@@ -126,8 +126,7 @@ class GoogleAdsCustomerMatchAbstractUploaderDoFn(beam.DoFn):
     utils.safe_call_api(self.call_api, logging, user_list_service, [mutate_members_operation])
 
   def call_api(self, service, operations):
-    r = service.mutateMembers(operations)
-    print(f'\n\n{r}\n\n')
+    service.mutateMembers(operations)
 
   def get_filtered_rows(self, rows: List[Any],
                         keys: List[str]) -> List[Dict[str, Any]]:


### PR DESCRIPTION
Hello. I've implemented a Firestore source, which is meant to work as an alternative for Sheets for parametrization purposes.

Why Firestore?
Some of our clients are unable to access the Spreadsheets domain for security purposes, and Firestore proved to be a great option. It provides reliable and dynamic storage, and is quite simple to use. Also, the expected usage level for Megalist should fall into the free tier.
Additionally, Firestore has great integration with App Engine. In a future PR, I’d like to add a highly customizable App Engine form integrated with Firestore, which provides an easy to use alternative to Sheets, especially for non-technical users unable to access it.

Requirements:
For now, Firestore usage requires a GCP project with native Firestore mode.

Usage:
The default fields for any upload type are: active (yes/no), bq_dataset, bq_table, source and type. Valid upload types and their required fields can be seen in the firestore_execution_source file.

As with Sheets, account IDs are included separately. In this case, in a Firestore document called account_config, within the same collection. In other words, the hierarchy is:
Firestore collection -> document entries for each schedule + account_config document.

In order to check Firestore, Megalist requires the setup_firestore_collection command line parameter. If setup_sheet_id is provided, Sheets will be used instead.

Improvement opportunities:
For now, the Firestore source expects BigQuery parameters, as it is the only ingest option currently available. This should be made flexible in the future, to allow options such as GCS.

The list of parameter metadata was included in firestore_execution_source, and could be modularized in the future.

Testing
I have only been able to test uploads to Google Ads and Google Analytics so far, as we generally lack access/test data to other platforms. Help with further testing would be greatly appreciated.